### PR TITLE
Manifest update

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
     "gecko": {
       "id": "awsomeautoarchive@opera.wang",
       "strict_min_version": "68.0",
-      "strict_max_version": "68.11"
+      "strict_max_version": "68.99"
     }
   },
   "version": "0.9.68beta-df",


### PR DESCRIPTION
Updated strict_max_version to "68.99", so that the add-on will load for all versions of TB68